### PR TITLE
feat(site[homepage]) Reactive Before/After demo with playground sandbox

### DIFF
--- a/packages/site/src/components/playground/BeforeAfterDemo.tsx
+++ b/packages/site/src/components/playground/BeforeAfterDemo.tsx
@@ -1,0 +1,125 @@
+import { convertUrlToEmbedUrl, getProviderFromUrl } from "@social-embed/lib";
+import { useCallback, useMemo, useState } from "react";
+import { CodeEditor } from "./CodeEditor";
+import { MiniPlayground } from "./MiniPlayground";
+
+/**
+ * Generate a representative iframe HTML blob for a given media URL.
+ * This shows what developers would have to store *without* social-embed.
+ */
+function generateIframeHtml(url: string): string {
+  const provider = getProviderFromUrl(url);
+  const embedUrl = convertUrlToEmbedUrl(url);
+
+  if (!provider || !embedUrl) {
+    return `<iframe\n  src="${url}"\n  width="560"\n  height="315"\n></iframe>`;
+  }
+
+  const name = provider.name;
+
+  // Provider-specific iframe attributes to show the ugly reality
+  const attrs: Record<string, string> = {
+    frameborder: "0",
+    height: "315",
+    src: embedUrl,
+    width: "560",
+  };
+
+  if (name === "YouTube") {
+    attrs.allow =
+      "accelerometer; autoplay;\n    clipboard-write; encrypted-media;\n    gyroscope; picture-in-picture";
+    attrs.allowfullscreen = "";
+  } else if (name === "Spotify") {
+    attrs.width = "100%";
+    attrs.height = "352";
+    attrs.allow =
+      "autoplay; clipboard-write;\n    encrypted-media; fullscreen;\n    picture-in-picture";
+    attrs.loading = "lazy";
+  } else if (name === "Vimeo") {
+    attrs.allow = "autoplay; fullscreen;\n    picture-in-picture";
+    attrs.allowfullscreen = "";
+  } else if (name === "DailyMotion") {
+    attrs.allow = "autoplay; fullscreen;\n    picture-in-picture; web-share";
+    attrs.allowfullscreen = "";
+  } else if (name === "Loom") {
+    attrs.allowfullscreen = "";
+    attrs.webkitallowfullscreen = "";
+    attrs.mozallowfullscreen = "";
+  } else {
+    attrs.allow = "autoplay; fullscreen";
+    attrs.allowfullscreen = "";
+  }
+
+  const lines = ["<iframe"];
+  for (const [key, val] of Object.entries(attrs)) {
+    if (val === "") {
+      lines.push(`  ${key}`);
+    } else {
+      lines.push(`  ${key}="${val}"`);
+    }
+  }
+  lines.push("></iframe>");
+  return lines.join("\n");
+}
+
+interface BeforeAfterDemoProps {
+  className?: string;
+}
+
+/**
+ * Before/After demo: read-only iframe code on the left,
+ * interactive <o-embed> playground on the right.
+ * The iframe code updates reactively when the playground URL changes.
+ */
+export function BeforeAfterDemo({ className = "" }: BeforeAfterDemoProps) {
+  const [currentUrl, setCurrentUrl] = useState(
+    "https://www.youtube.com/watch?v=EJxwWpaGoJs",
+  );
+
+  const iframeHtml = useMemo(
+    () => generateIframeHtml(currentUrl),
+    [currentUrl],
+  );
+
+  const handleCodeChange = useCallback((code: string) => {
+    // Extract URL from the snippet code
+    const match = code.match(/url="([^"]+)"/);
+    if (match?.[1]) {
+      setCurrentUrl(match[1]);
+    }
+  }, []);
+
+  return (
+    <div className={`grid grid-cols-1 lg:grid-cols-2 gap-6 ${className}`}>
+      <div className="flex flex-col">
+        <p className="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400 mb-2">
+          Before — stored in your database
+        </p>
+        <div className="flex-1 rounded-lg border border-slate-200 dark:border-slate-700 overflow-hidden">
+          <CodeEditor
+            className="h-full"
+            language="html"
+            onChange={() => {}}
+            readOnly
+            value={iframeHtml}
+          />
+        </div>
+      </div>
+      <div className="flex flex-col">
+        <p className="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400 mb-2">
+          After —{" "}
+          <code className="text-indigo-600 dark:text-indigo-400">
+            &lt;o-embed&gt;
+          </code>
+        </p>
+        <MiniPlayground
+          className="h-full"
+          codeHeight="50px"
+          iframeHeight="350px"
+          initialViewMode="snippet"
+          onSnippetChange={handleCodeChange}
+        />
+      </div>
+    </div>
+  );
+}

--- a/packages/site/src/components/playground/MiniPlayground.tsx
+++ b/packages/site/src/components/playground/MiniPlayground.tsx
@@ -14,7 +14,14 @@ import {
   PreviewPane,
   type PreviewPaneHandle,
 } from "./PreviewPane";
-import { DEFAULT_PRESET, getPresetById, PRESETS } from "./presets";
+import {
+  DEFAULT_PRESET,
+  extractSnippet,
+  getPresetById,
+  PRESETS,
+  type ViewMode,
+  wrapSnippet,
+} from "./presets";
 import { RerollButton } from "./RerollButton";
 import {
   applySeededUrls,
@@ -78,6 +85,8 @@ export interface MiniPlaygroundProps {
   initialCode?: string;
   /** Initial preset ID */
   initialPreset?: string;
+  /** Initial view mode: "full" shows complete HTML, "snippet" shows only body content */
+  initialViewMode?: ViewMode;
 }
 
 /**
@@ -90,7 +99,9 @@ export function MiniPlayground({
   iframeHeight,
   initialCode,
   initialPreset,
+  initialViewMode = "full",
 }: MiniPlaygroundProps) {
+  const [viewMode, setViewMode] = useState<ViewMode>(initialViewMode);
   // Determine initial preset and code
   const [presetId, setPresetId] = useState(() => {
     if (initialCode) return undefined; // Custom code, no preset
@@ -99,12 +110,16 @@ export function MiniPlayground({
   });
 
   const [code, setCode] = useState(() => {
-    if (initialCode) return initialCode;
-    if (initialPreset) {
+    let fullCode: string;
+    if (initialCode) {
+      fullCode = initialCode;
+    } else if (initialPreset) {
       const preset = getPresetById(initialPreset);
-      return preset?.code ?? DEFAULT_PRESET.code;
+      fullCode = preset?.code ?? DEFAULT_PRESET.code;
+    } else {
+      fullCode = DEFAULT_PRESET.code;
     }
-    return DEFAULT_PRESET.code;
+    return initialViewMode === "snippet" ? extractSnippet(fullCode) : fullCode;
   });
 
   // Template for reroll (preserves original code with URL placeholders)
@@ -165,26 +180,44 @@ export function MiniPlayground({
     setConsoleLogs([]); // Clear console on CDN change
   }, []);
 
-  const handlePresetChange = useCallback((id: string) => {
-    const preset = getPresetById(id);
-    if (preset) {
-      setCode(preset.code);
-      setPresetId(id);
-      setTemplateCode(undefined);
-      setSeed(undefined);
-      setConsoleLogs([]);
-    }
+  const handleViewModeToggle = useCallback(() => {
+    setViewMode((prev) => {
+      const next = prev === "full" ? "snippet" : "full";
+      setCode((currentCode) =>
+        next === "snippet"
+          ? extractSnippet(currentCode)
+          : wrapSnippet(currentCode),
+      );
+      return next;
+    });
   }, []);
+
+  const handlePresetChange = useCallback(
+    (id: string) => {
+      const preset = getPresetById(id);
+      if (preset) {
+        setCode(
+          viewMode === "snippet" ? extractSnippet(preset.code) : preset.code,
+        );
+        setPresetId(id);
+        setTemplateCode(undefined);
+        setSeed(undefined);
+        setConsoleLogs([]);
+      }
+    },
+    [viewMode],
+  );
 
   // Reroll handler - generates new seed and updates URLs
   const handleReroll = useCallback(() => {
     const newSeed = generateSeed();
 
-    // Get template (existing template or current code)
-    const template = templateCode ?? code;
+    // Get full HTML template (existing template, or wrap snippet if in snippet mode)
+    const currentFull =
+      templateCode ?? (viewMode === "snippet" ? wrapSnippet(code) : code);
 
     // Reactive update via postMessage (no iframe reload)
-    const updates = generateReactiveUpdates(template, newSeed);
+    const updates = generateReactiveUpdates(currentFull, newSeed);
     for (const update of updates) {
       previewRef.current?.updateAttribute(
         update.selector,
@@ -194,12 +227,12 @@ export function MiniPlayground({
     }
 
     // Compute display code from template + seed
-    const { html } = applySeededUrls(template, newSeed);
+    const { html: fullHtml } = applySeededUrls(currentFull, newSeed);
 
-    setCode(html);
-    setTemplateCode(template); // Preserve template for future rerolls
+    setCode(viewMode === "snippet" ? extractSnippet(fullHtml) : fullHtml);
+    setTemplateCode(currentFull); // Preserve full template for future rerolls
     setSeed(newSeed); // Store seed for compact share links
-  }, [code, templateCode]);
+  }, [code, templateCode, viewMode]);
 
   // Check if current code can be randomized
   const canReroll = useMemo(() => canRandomize(code), [code]);
@@ -263,6 +296,27 @@ export function MiniPlayground({
             </option>
           ))}
         </select>
+
+        {/* View mode toggle */}
+        <button
+          className={`
+            h-7 px-2 text-xs font-medium border rounded transition-colors cursor-pointer
+            ${
+              viewMode === "snippet"
+                ? "bg-indigo-50 dark:bg-indigo-950 text-indigo-600 dark:text-indigo-400 border-indigo-300 dark:border-indigo-700"
+                : "bg-white dark:bg-slate-800 text-slate-700 dark:text-slate-300 border-slate-300 dark:border-slate-600 hover:border-slate-400 dark:hover:border-slate-500"
+            }
+          `}
+          onClick={handleViewModeToggle}
+          title={
+            viewMode === "snippet"
+              ? "Show full HTML page"
+              : "Show only the embed tag"
+          }
+          type="button"
+        >
+          {viewMode === "snippet" ? "Tag" : "HTML"}
+        </button>
 
         {canReroll && <RerollButton onClick={handleReroll} variant="sm" />}
       </div>
@@ -333,6 +387,7 @@ export function MiniPlayground({
               code={stableCode}
               onConsoleMessage={handleConsoleMessage}
               ref={previewRef}
+              viewMode={viewMode}
               wcUrl={cdnUrls.wc}
             />
           </div>

--- a/packages/site/src/components/playground/MiniPlayground.tsx
+++ b/packages/site/src/components/playground/MiniPlayground.tsx
@@ -87,6 +87,8 @@ export interface MiniPlaygroundProps {
   initialPreset?: string;
   /** Initial view mode: "full" shows complete HTML, "snippet" shows only body content */
   initialViewMode?: ViewMode;
+  /** Called when the displayed code changes (after reroll, preset switch, or edit) */
+  onSnippetChange?: (code: string) => void;
 }
 
 /**
@@ -100,6 +102,7 @@ export function MiniPlayground({
   initialCode,
   initialPreset,
   initialViewMode = "full",
+  onSnippetChange,
 }: MiniPlaygroundProps) {
   const [viewMode, setViewMode] = useState<ViewMode>(initialViewMode);
   // Determine initial preset and code
@@ -146,6 +149,11 @@ export function MiniPlayground({
     }, 500);
     return () => clearTimeout(timer);
   }, [code]);
+
+  // Notify parent when code changes
+  useEffect(() => {
+    onSnippetChange?.(code);
+  }, [code, onSnippetChange]);
 
   // Handle code changes from editor
   const handleCodeChange = useCallback((newCode: string) => {

--- a/packages/site/src/components/playground/MiniPlayground.tsx
+++ b/packages/site/src/components/playground/MiniPlayground.tsx
@@ -350,9 +350,8 @@ export function MiniPlayground({
         <div
           className={`
             ${activeTab === "code" ? "flex" : "hidden"}
-            sm:flex min-h-[150px]
+            sm:flex ${codeHeight ? "" : "min-h-[150px] flex-1"}
             border-b border-slate-200 dark:border-slate-700
-            ${codeHeight ? "" : "flex-1"}
           `}
           style={codeHeight ? { flexShrink: 0, height: codeHeight } : undefined}
         >

--- a/packages/site/src/components/playground/MiniPlayground.tsx
+++ b/packages/site/src/components/playground/MiniPlayground.tsx
@@ -14,7 +14,14 @@ import {
   PreviewPane,
   type PreviewPaneHandle,
 } from "./PreviewPane";
-import { DEFAULT_PRESET, getPresetById, PRESETS } from "./presets";
+import {
+  DEFAULT_PRESET,
+  extractSnippet,
+  getPresetById,
+  PRESETS,
+  type ViewMode,
+  wrapSnippet,
+} from "./presets";
 import { RerollButton } from "./RerollButton";
 import {
   applySeededUrls,
@@ -78,6 +85,8 @@ interface MiniPlaygroundProps {
   initialCode?: string;
   /** Initial preset ID */
   initialPreset?: string;
+  /** Initial view mode: "full" shows complete HTML, "snippet" shows only body content */
+  initialViewMode?: ViewMode;
 }
 
 /**
@@ -90,7 +99,9 @@ export function MiniPlayground({
   iframeHeight,
   initialCode,
   initialPreset,
+  initialViewMode = "full",
 }: MiniPlaygroundProps) {
+  const [viewMode, setViewMode] = useState<ViewMode>(initialViewMode);
   // Determine initial preset and code
   const [presetId, setPresetId] = useState(() => {
     if (initialCode) return undefined; // Custom code, no preset
@@ -99,12 +110,16 @@ export function MiniPlayground({
   });
 
   const [code, setCode] = useState(() => {
-    if (initialCode) return initialCode;
-    if (initialPreset) {
+    let fullCode: string;
+    if (initialCode) {
+      fullCode = initialCode;
+    } else if (initialPreset) {
       const preset = getPresetById(initialPreset);
-      return preset?.code ?? DEFAULT_PRESET.code;
+      fullCode = preset?.code ?? DEFAULT_PRESET.code;
+    } else {
+      fullCode = DEFAULT_PRESET.code;
     }
-    return DEFAULT_PRESET.code;
+    return initialViewMode === "snippet" ? extractSnippet(fullCode) : fullCode;
   });
 
   // Template for reroll (preserves original code with URL placeholders)
@@ -165,26 +180,44 @@ export function MiniPlayground({
     setConsoleLogs([]); // Clear console on CDN change
   }, []);
 
-  const handlePresetChange = useCallback((id: string) => {
-    const preset = getPresetById(id);
-    if (preset) {
-      setCode(preset.code);
-      setPresetId(id);
-      setTemplateCode(undefined);
-      setSeed(undefined);
-      setConsoleLogs([]);
-    }
+  const handleViewModeToggle = useCallback(() => {
+    setViewMode((prev) => {
+      const next = prev === "full" ? "snippet" : "full";
+      setCode((currentCode) =>
+        next === "snippet"
+          ? extractSnippet(currentCode)
+          : wrapSnippet(currentCode),
+      );
+      return next;
+    });
   }, []);
+
+  const handlePresetChange = useCallback(
+    (id: string) => {
+      const preset = getPresetById(id);
+      if (preset) {
+        setCode(
+          viewMode === "snippet" ? extractSnippet(preset.code) : preset.code,
+        );
+        setPresetId(id);
+        setTemplateCode(undefined);
+        setSeed(undefined);
+        setConsoleLogs([]);
+      }
+    },
+    [viewMode],
+  );
 
   // Reroll handler - generates new seed and updates URLs
   const handleReroll = useCallback(() => {
     const newSeed = generateSeed();
 
-    // Get template (existing template or current code)
-    const template = templateCode ?? code;
+    // Get full HTML template (existing template, or wrap snippet if in snippet mode)
+    const currentFull =
+      templateCode ?? (viewMode === "snippet" ? wrapSnippet(code) : code);
 
     // Reactive update via postMessage (no iframe reload)
-    const updates = generateReactiveUpdates(template, newSeed);
+    const updates = generateReactiveUpdates(currentFull, newSeed);
     for (const update of updates) {
       previewRef.current?.updateAttribute(
         update.selector,
@@ -194,12 +227,12 @@ export function MiniPlayground({
     }
 
     // Compute display code from template + seed
-    const { html } = applySeededUrls(template, newSeed);
+    const { html: fullHtml } = applySeededUrls(currentFull, newSeed);
 
-    setCode(html);
-    setTemplateCode(template); // Preserve template for future rerolls
+    setCode(viewMode === "snippet" ? extractSnippet(fullHtml) : fullHtml);
+    setTemplateCode(currentFull); // Preserve full template for future rerolls
     setSeed(newSeed); // Store seed for compact share links
-  }, [code, templateCode]);
+  }, [code, templateCode, viewMode]);
 
   // Check if current code can be randomized
   const canReroll = useMemo(() => canRandomize(code), [code]);
@@ -263,6 +296,27 @@ export function MiniPlayground({
             </option>
           ))}
         </select>
+
+        {/* View mode toggle */}
+        <button
+          className={`
+            h-7 px-2 text-xs font-medium border rounded transition-colors cursor-pointer
+            ${
+              viewMode === "snippet"
+                ? "bg-indigo-50 dark:bg-indigo-950 text-indigo-600 dark:text-indigo-400 border-indigo-300 dark:border-indigo-700"
+                : "bg-white dark:bg-slate-800 text-slate-700 dark:text-slate-300 border-slate-300 dark:border-slate-600 hover:border-slate-400 dark:hover:border-slate-500"
+            }
+          `}
+          onClick={handleViewModeToggle}
+          title={
+            viewMode === "snippet"
+              ? "Show full HTML page"
+              : "Show only the embed tag"
+          }
+          type="button"
+        >
+          {viewMode === "snippet" ? "Tag" : "HTML"}
+        </button>
 
         {canReroll && <RerollButton onClick={handleReroll} variant="sm" />}
       </div>
@@ -333,6 +387,7 @@ export function MiniPlayground({
               code={stableCode}
               onConsoleMessage={handleConsoleMessage}
               ref={previewRef}
+              viewMode={viewMode}
               wcUrl={cdnUrls.wc}
             />
           </div>

--- a/packages/site/src/components/playground/MiniPlayground.tsx
+++ b/packages/site/src/components/playground/MiniPlayground.tsx
@@ -87,6 +87,8 @@ interface MiniPlaygroundProps {
   initialPreset?: string;
   /** Initial view mode: "full" shows complete HTML, "snippet" shows only body content */
   initialViewMode?: ViewMode;
+  /** Called when the displayed code changes (after reroll, preset switch, or edit) */
+  onSnippetChange?: (code: string) => void;
 }
 
 /**
@@ -100,6 +102,7 @@ export function MiniPlayground({
   initialCode,
   initialPreset,
   initialViewMode = "full",
+  onSnippetChange,
 }: MiniPlaygroundProps) {
   const [viewMode, setViewMode] = useState<ViewMode>(initialViewMode);
   // Determine initial preset and code
@@ -146,6 +149,11 @@ export function MiniPlayground({
     }, 500);
     return () => clearTimeout(timer);
   }, [code]);
+
+  // Notify parent when code changes
+  useEffect(() => {
+    onSnippetChange?.(code);
+  }, [code, onSnippetChange]);
 
   // Handle code changes from editor
   const handleCodeChange = useCallback((newCode: string) => {

--- a/packages/site/src/components/playground/Playground.tsx
+++ b/packages/site/src/components/playground/Playground.tsx
@@ -15,7 +15,15 @@ import {
   PreviewPane,
   type PreviewPaneHandle,
 } from "./PreviewPane";
-import { DEFAULT_PRESET, getPresetById, PRESETS, type Preset } from "./presets";
+import {
+  DEFAULT_PRESET,
+  extractSnippet,
+  getPresetById,
+  PRESETS,
+  type Preset,
+  type ViewMode,
+  wrapSnippet,
+} from "./presets";
 import { RerollButton } from "./RerollButton";
 import {
   applySeededUrls,
@@ -90,6 +98,7 @@ export function Playground() {
         };
   });
 
+  const [viewMode, setViewMode] = useState<ViewMode>("full");
   const [consoleLogs, setConsoleLogs] = useState<ConsoleEntry[]>([]);
   const [stableCode, setStableCode] = useState(state.code);
   const previewRef = useRef<PreviewPaneHandle>(null);
@@ -134,16 +143,31 @@ export function Playground() {
     setConsoleLogs([]); // Clear console on CDN change
   }, []);
 
-  const handlePresetChange = useCallback((preset: Preset) => {
-    setState((prev) => ({
-      ...prev,
-      code: preset.code,
-      presetId: preset.id,
-      seed: undefined, // Clear any previous seed
-      templateCode: undefined, // Will be derived from presetId
-    }));
-    setConsoleLogs([]); // Clear console on preset change
+  const handleViewModeToggle = useCallback(() => {
+    setViewMode((prev) => {
+      const next = prev === "full" ? "snippet" : "full";
+      setState((s) => ({
+        ...s,
+        code: next === "snippet" ? extractSnippet(s.code) : wrapSnippet(s.code),
+      }));
+      return next;
+    });
   }, []);
+
+  const handlePresetChange = useCallback(
+    (preset: Preset) => {
+      setState((prev) => ({
+        ...prev,
+        code:
+          viewMode === "snippet" ? extractSnippet(preset.code) : preset.code,
+        presetId: preset.id,
+        seed: undefined,
+        templateCode: undefined,
+      }));
+      setConsoleLogs([]);
+    },
+    [viewMode],
+  );
 
   const handleConsoleMessage = useCallback((entry: ConsoleEntry) => {
     setConsoleLogs((prev) => [...prev, entry]);
@@ -157,11 +181,11 @@ export function Playground() {
   const handleReroll = useCallback(() => {
     const newSeed = generateSeed();
 
-    // Get template (preset code, existing template, or current code)
+    // Get full HTML template (preset code, existing template, or current code)
     const template =
       state.templateCode ??
       (state.presetId ? getPresetById(state.presetId)?.code : undefined) ??
-      state.code;
+      (viewMode === "snippet" ? wrapSnippet(state.code) : state.code);
 
     // Reactive update via postMessage (no iframe reload)
     const updates = generateReactiveUpdates(template, newSeed);
@@ -174,15 +198,15 @@ export function Playground() {
     }
 
     // Compute display code from template + seed
-    const { html } = applySeededUrls(template, newSeed);
+    const { html: fullHtml } = applySeededUrls(template, newSeed);
 
     setState((prev) => ({
       ...prev,
-      code: html, // Display code for editor
+      code: viewMode === "snippet" ? extractSnippet(fullHtml) : fullHtml,
       seed: newSeed,
-      templateCode: template, // Preserve template for URL encoding
+      templateCode: template,
     }));
-  }, [state.code, state.templateCode, state.presetId]);
+  }, [state.code, state.templateCode, state.presetId, viewMode]);
 
   // Check if current code can be randomized
   const canReroll = useMemo(() => canRandomize(state.code), [state.code]);
@@ -215,6 +239,27 @@ export function Playground() {
 
         {/* Reroll button */}
         {canReroll && <RerollButton onClick={handleReroll} variant="sm" />}
+
+        {/* View mode toggle */}
+        <button
+          className={`
+            h-[26px] px-2 py-1 text-xs font-medium border rounded transition-colors cursor-pointer select-none
+            ${
+              viewMode === "snippet"
+                ? "bg-indigo-50 dark:bg-indigo-950 text-indigo-600 dark:text-indigo-400 border-indigo-300 dark:border-indigo-700"
+                : "bg-white dark:bg-slate-800 text-slate-700 dark:text-slate-300 border-slate-300 dark:border-slate-600 hover:border-slate-400 dark:hover:border-slate-500"
+            }
+          `}
+          onClick={handleViewModeToggle}
+          title={
+            viewMode === "snippet"
+              ? "Show full HTML page"
+              : "Show only the embed tag"
+          }
+          type="button"
+        >
+          {viewMode === "snippet" ? "Tag" : "HTML"}
+        </button>
 
         {/* CDN source picker */}
         <div className="flex-1 min-w-[300px]">
@@ -269,6 +314,7 @@ export function Playground() {
               code={stableCode}
               onConsoleMessage={handleConsoleMessage}
               ref={previewRef}
+              viewMode={viewMode}
               wcUrl={cdnUrls.wc}
             />
           </div>

--- a/packages/site/src/components/playground/PreviewPane.tsx
+++ b/packages/site/src/components/playground/PreviewPane.tsx
@@ -6,6 +6,7 @@ import {
   useMemo,
   useRef,
 } from "react";
+import { type ViewMode, wrapSnippet } from "./presets";
 
 export interface ConsoleEntry {
   id: string;
@@ -19,6 +20,8 @@ export interface PreviewPaneProps {
   wcUrl: string;
   onConsoleMessage?: (entry: ConsoleEntry) => void;
   className?: string;
+  /** When "snippet", wraps code in the standard HTML page template before rendering */
+  viewMode?: ViewMode;
 }
 
 export interface PreviewPaneHandle {
@@ -99,9 +102,16 @@ function getConsoleCaptureScript(): string {
 /**
  * Generate the full srcdoc HTML with WC URL replaced and scripts injected.
  */
-function generateSrcdoc(code: string, wcUrl: string): string {
+function generateSrcdoc(
+  code: string,
+  wcUrl: string,
+  viewMode: ViewMode = "full",
+): string {
+  // In snippet mode, wrap the code in a full HTML page first
+  const sourceCode = viewMode === "snippet" ? wrapSnippet(code) : code;
+
   // Replace {{WC_URL}} placeholder with actual WC URL
-  let processedCode = code.replace(/\{\{WC_URL\}\}/g, wcUrl);
+  let processedCode = sourceCode.replace(/\{\{WC_URL\}\}/g, wcUrl);
 
   // Inject console capture script after <head> tag
   const consoleCaptureScript = getConsoleCaptureScript();
@@ -128,7 +138,10 @@ function generateSrcdoc(code: string, wcUrl: string): string {
  * Sandboxed iframe preview for the playground.
  */
 export const PreviewPane = forwardRef<PreviewPaneHandle, PreviewPaneProps>(
-  function PreviewPane({ code, wcUrl, onConsoleMessage, className = "" }, ref) {
+  function PreviewPane(
+    { code, wcUrl, onConsoleMessage, className = "", viewMode = "full" },
+    ref,
+  ) {
     const iframeRef = useRef<HTMLIFrameElement>(null);
 
     // Expose updateAttribute method to parent via ref
@@ -150,7 +163,10 @@ export const PreviewPane = forwardRef<PreviewPaneHandle, PreviewPaneProps>(
     useImperativeHandle(ref, () => ({ updateAttribute }), [updateAttribute]);
 
     // Generate srcdoc from inputs
-    const srcdoc = useMemo(() => generateSrcdoc(code, wcUrl), [code, wcUrl]);
+    const srcdoc = useMemo(
+      () => generateSrcdoc(code, wcUrl, viewMode),
+      [code, wcUrl, viewMode],
+    );
 
     // Listen for postMessage from iframe
     const handleMessage = useCallback(

--- a/packages/site/src/components/playground/PreviewPane.tsx
+++ b/packages/site/src/components/playground/PreviewPane.tsx
@@ -6,6 +6,7 @@ import {
   useMemo,
   useRef,
 } from "react";
+import { type ViewMode, wrapSnippet } from "./presets";
 
 export interface ConsoleEntry {
   id: string;
@@ -19,6 +20,8 @@ interface PreviewPaneProps {
   wcUrl: string;
   onConsoleMessage?: (entry: ConsoleEntry) => void;
   className?: string;
+  /** When "snippet", wraps code in the standard HTML page template before rendering */
+  viewMode?: ViewMode;
 }
 
 export interface PreviewPaneHandle {
@@ -99,9 +102,16 @@ function getConsoleCaptureScript(): string {
 /**
  * Generate the full srcdoc HTML with WC URL replaced and scripts injected.
  */
-function generateSrcdoc(code: string, wcUrl: string): string {
+function generateSrcdoc(
+  code: string,
+  wcUrl: string,
+  viewMode: ViewMode = "full",
+): string {
+  // In snippet mode, wrap the code in a full HTML page first
+  const sourceCode = viewMode === "snippet" ? wrapSnippet(code) : code;
+
   // Replace {{WC_URL}} placeholder with actual WC URL
-  let processedCode = code.replace(/\{\{WC_URL\}\}/g, wcUrl);
+  let processedCode = sourceCode.replace(/\{\{WC_URL\}\}/g, wcUrl);
 
   // Inject console capture script after <head> tag
   const consoleCaptureScript = getConsoleCaptureScript();
@@ -128,7 +138,10 @@ function generateSrcdoc(code: string, wcUrl: string): string {
  * Sandboxed iframe preview for the playground.
  */
 export const PreviewPane = forwardRef<PreviewPaneHandle, PreviewPaneProps>(
-  function PreviewPane({ code, wcUrl, onConsoleMessage, className = "" }, ref) {
+  function PreviewPane(
+    { code, wcUrl, onConsoleMessage, className = "", viewMode = "full" },
+    ref,
+  ) {
     const iframeRef = useRef<HTMLIFrameElement>(null);
 
     // Expose updateAttribute method to parent via ref
@@ -150,7 +163,10 @@ export const PreviewPane = forwardRef<PreviewPaneHandle, PreviewPaneProps>(
     useImperativeHandle(ref, () => ({ updateAttribute }), [updateAttribute]);
 
     // Generate srcdoc from inputs
-    const srcdoc = useMemo(() => generateSrcdoc(code, wcUrl), [code, wcUrl]);
+    const srcdoc = useMemo(
+      () => generateSrcdoc(code, wcUrl, viewMode),
+      [code, wcUrl, viewMode],
+    );
 
     // Listen for postMessage from iframe
     const handleMessage = useCallback(

--- a/packages/site/src/components/playground/presets.ts
+++ b/packages/site/src/components/playground/presets.ts
@@ -13,11 +13,18 @@ export interface Preset {
 
 /**
  * Extract the inner body content from a full HTML page.
+ * Strips heading tags and leading indentation for a clean snippet.
  * Returns the original string if no <body> tag is found.
  */
 export function extractSnippet(fullHtml: string): string {
   const match = fullHtml.match(/<body[^>]*>([\s\S]*?)<\/body>/i);
-  return match ? match[1].trim() : fullHtml;
+  if (!match) return fullHtml;
+  return match[1]
+    .replace(/<h[1-6][^>]*>[\s\S]*?<\/h[1-6]>\s*/gi, "")
+    .split("\n")
+    .map((line) => line.replace(/^ {2}/, ""))
+    .join("\n")
+    .trim();
 }
 
 /**
@@ -25,6 +32,10 @@ export function extractSnippet(fullHtml: string): string {
  * Uses {{WC_URL}} placeholder for CDN replacement in PreviewPane.
  */
 export function wrapSnippet(snippet: string): string {
+  const indented = snippet
+    .split("\n")
+    .map((line) => (line.trim() ? `  ${line}` : line))
+    .join("\n");
   return `<!DOCTYPE html>
 <html>
 <head>
@@ -35,7 +46,7 @@ export function wrapSnippet(snippet: string): string {
   </style>
 </head>
 <body>
-  ${snippet}
+${indented}
 </body>
 </html>`;
 }

--- a/packages/site/src/components/playground/presets.ts
+++ b/packages/site/src/components/playground/presets.ts
@@ -2,11 +2,42 @@
  * Provider-focused preset code examples for the playground.
  */
 
+export type ViewMode = "full" | "snippet";
+
 export interface Preset {
   id: string;
   name: string;
   description: string;
   code: string;
+}
+
+/**
+ * Extract the inner body content from a full HTML page.
+ * Returns the original string if no <body> tag is found.
+ */
+export function extractSnippet(fullHtml: string): string {
+  const match = fullHtml.match(/<body[^>]*>([\s\S]*?)<\/body>/i);
+  return match ? match[1].trim() : fullHtml;
+}
+
+/**
+ * Wrap a snippet in the standard HTML page template.
+ * Uses {{WC_URL}} placeholder for CDN replacement in PreviewPane.
+ */
+export function wrapSnippet(snippet: string): string {
+  return `<!DOCTYPE html>
+<html>
+<head>
+  ${WC_SCRIPT}
+  <style>
+    body { font-family: system-ui; }
+    o-embed { max-width: 560px; }
+  </style>
+</head>
+<body>
+  ${snippet}
+</body>
+</html>`;
 }
 
 const WC_SCRIPT = '<script type="module" src="{{WC_URL}}"></script>';

--- a/packages/site/src/pages/index.astro
+++ b/packages/site/src/pages/index.astro
@@ -98,25 +98,23 @@ import { ReadonlyCode } from "../components/playground/ReadonlyCode";
       </div>
 
       <!-- Before / After -->
-      <div class="max-w-6xl mx-auto mb-12">
-        <div class="grid grid-cols-1 lg:grid-cols-2 gap-6">
-          <div>
-            <p class="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400 mb-2">Before — stored in your database</p>
-            <ReadonlyCode
-              client:only="react"
-              code={`<iframe width="560" height="315"
+      <div class="grid grid-cols-1 lg:grid-cols-2 gap-6 mb-12">
+        <div>
+          <p class="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400 mb-2">Before — stored in your database</p>
+          <ReadonlyCode
+            client:only="react"
+            code={`<iframe width="560" height="315"
   src="https://www.youtube.com/embed/Bd8_vO5zrjo"
   frameborder="0"
   allow="accelerometer; autoplay;
     clipboard-write; encrypted-media;
     gyroscope; picture-in-picture"
   allowfullscreen></iframe>`}
-            />
-          </div>
-          <div class="flex flex-col">
-            <p class="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400 mb-2">After — <code class="text-indigo-600 dark:text-indigo-400">&lt;o-embed&gt;</code></p>
-            <MiniPlayground client:only="react" className="flex-1" codeHeight="150px" iframeHeight="315px" initialViewMode="snippet" />
-          </div>
+          />
+        </div>
+        <div class="flex flex-col">
+          <p class="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400 mb-2">After — <code class="text-indigo-600 dark:text-indigo-400">&lt;o-embed&gt;</code></p>
+          <MiniPlayground client:only="react" className="h-full" codeHeight="275px" iframeHeight="425px" initialViewMode="snippet" />
         </div>
       </div>
 

--- a/packages/site/src/pages/index.astro
+++ b/packages/site/src/pages/index.astro
@@ -114,7 +114,7 @@ import { ReadonlyCode } from "../components/playground/ReadonlyCode";
         </div>
         <div class="flex flex-col">
           <p class="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400 mb-2">After — <code class="text-indigo-600 dark:text-indigo-400">&lt;o-embed&gt;</code></p>
-          <MiniPlayground client:only="react" className="h-full" codeHeight="275px" iframeHeight="425px" initialViewMode="snippet" />
+          <MiniPlayground client:only="react" className="h-full" codeHeight="50px" iframeHeight="350px" initialViewMode="snippet" />
         </div>
       </div>
 

--- a/packages/site/src/pages/index.astro
+++ b/packages/site/src/pages/index.astro
@@ -98,7 +98,7 @@ import { ReadonlyCode } from "../components/playground/ReadonlyCode";
       </div>
 
       <!-- Before / After -->
-      <div class="mb-12">
+      <div class="max-w-6xl mx-auto mb-12">
         <div class="grid grid-cols-1 lg:grid-cols-2 gap-6">
           <div>
             <p class="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400 mb-2">Before — stored in your database</p>
@@ -113,17 +113,9 @@ import { ReadonlyCode } from "../components/playground/ReadonlyCode";
   allowfullscreen></iframe>`}
             />
           </div>
-          <div>
-            <p class="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400 mb-2">After — stored now</p>
-            <ReadonlyCode
-              client:only="react"
-              code={`<o-embed
-  url="https://www.youtube.com/watch?v=Bd8_vO5zrjo"
-></o-embed>`}
-            />
-            <p class="text-xs text-slate-500 dark:text-slate-400 mt-2">
-              The URL is the data. Provider detection, embed URL construction, and rendering happen at render time. <a href="#playground" class="text-indigo-600 dark:text-indigo-400 hover:underline">See example</a>
-            </p>
+          <div class="flex flex-col">
+            <p class="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400 mb-2">After — <code class="text-indigo-600 dark:text-indigo-400">&lt;o-embed&gt;</code></p>
+            <MiniPlayground client:only="react" className="flex-1" codeHeight="150px" iframeHeight="315px" />
           </div>
         </div>
       </div>

--- a/packages/site/src/pages/index.astro
+++ b/packages/site/src/pages/index.astro
@@ -13,6 +13,7 @@ import PureSocialIcons from "../components/core/PureSocialIcons.astro";
 import PureThemeSelect from "../components/core/PureThemeSelect.astro";
 import GitPullLogo from "../components/GitPullLogo.astro";
 import { LibPlayground } from "../components/lib-playground/LibPlayground";
+import { BeforeAfterDemo } from "../components/playground/BeforeAfterDemo";
 import { MiniPlayground } from "../components/playground/MiniPlayground";
 import { ReadonlyCode } from "../components/playground/ReadonlyCode";
 ---
@@ -98,25 +99,7 @@ import { ReadonlyCode } from "../components/playground/ReadonlyCode";
       </div>
 
       <!-- Before / After -->
-      <div class="grid grid-cols-1 lg:grid-cols-2 gap-6 mb-12">
-        <div>
-          <p class="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400 mb-2">Before — stored in your database</p>
-          <ReadonlyCode
-            client:only="react"
-            code={`<iframe width="560" height="315"
-  src="https://www.youtube.com/embed/Bd8_vO5zrjo"
-  frameborder="0"
-  allow="accelerometer; autoplay;
-    clipboard-write; encrypted-media;
-    gyroscope; picture-in-picture"
-  allowfullscreen></iframe>`}
-          />
-        </div>
-        <div class="flex flex-col">
-          <p class="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400 mb-2">After — <code class="text-indigo-600 dark:text-indigo-400">&lt;o-embed&gt;</code></p>
-          <MiniPlayground client:only="react" className="h-full" codeHeight="50px" iframeHeight="350px" initialViewMode="snippet" />
-        </div>
-      </div>
+      <BeforeAfterDemo client:only="react" className="mb-12" />
 
       <!-- Use cases -->
       <div class="max-w-4xl mx-auto mb-12">

--- a/packages/site/src/pages/index.astro
+++ b/packages/site/src/pages/index.astro
@@ -115,7 +115,7 @@ import { ReadonlyCode } from "../components/playground/ReadonlyCode";
           </div>
           <div class="flex flex-col">
             <p class="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400 mb-2">After — <code class="text-indigo-600 dark:text-indigo-400">&lt;o-embed&gt;</code></p>
-            <MiniPlayground client:only="react" className="flex-1" codeHeight="150px" iframeHeight="315px" />
+            <MiniPlayground client:only="react" className="flex-1" codeHeight="150px" iframeHeight="315px" initialViewMode="snippet" />
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary

Replaces the static Before/After code comparison on the homepage with a reactive demo: changing the URL in the After playground automatically regenerates the provider-specific iframe HTML in the Before column. Shows the real pain of raw iframes vs the simplicity of `<o-embed>`.

- **BeforeAfterDemo component**: Reactive two-column layout — readonly CodeMirror on the left shows the generated iframe blob, MiniPlayground on the right is interactive
- **Snippet view mode**: New `viewMode` toggle for MiniPlayground and Playground — switches between full HTML page and clean `<o-embed>` snippet
- **Snippet utilities**: `extractSnippet()` / `wrapSnippet()` for converting between full page and body-only views

## Changes

- **New**: `BeforeAfterDemo.tsx` — generates provider-specific iframe HTML reactively from the playground URL using `convertUrlToEmbedUrl()` and `getProviderFromUrl()`
- **New**: `presets.ts` additions — `ViewMode` type, `extractSnippet()`, `wrapSnippet()` utilities
- **Modified**: `MiniPlayground.tsx` — add `initialViewMode` prop, snippet/full toggle, `onSnippetChange` callback
- **Modified**: `Playground.tsx` — add `viewMode` toggle with same snippet/full behavior
- **Modified**: `PreviewPane.tsx` — accept `viewMode` to control snippet extraction
- **Modified**: `index.astro` — replace inline Before/After markup with `<BeforeAfterDemo />`

## Test plan

- [x] `pnpm --filter site build` passes (43 pages)
- [ ] Visual: toggle URL in After playground, verify Before iframe code updates reactively
- [ ] Visual: snippet/full toggle works in both MiniPlayground and full Playground
- [ ] Visual: responsive layout (single column on mobile, two columns on lg+)